### PR TITLE
Add pagination

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,3 @@ jobs:
         tox_env: [black, py36, py37, py38, py39]
 
     runs-on: ubuntu-latest
-    

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -252,16 +252,14 @@ def show_cve(ctx, print_raw, cve_id):
 @pass_config
 @handle_idr_exc
 def list_cves(ctx, print_raw, sort_by, **query):
-    """Filter and list CVE IDs owned by your CNA."""
+    """Filter and list reserved CVE IDs owned by your CNA."""
     idr = ctx.init_idr()
-    response = idr.list_cves(**query)
-    cve_data = response.json()
+    cves = list(idr.list_cves(**query))
 
     if print_raw:
-        click.echo(json.dumps(cve_data, indent=4, sort_keys=True))
+        click.echo(json.dumps(cves, indent=4, sort_keys=True))
         return
 
-    cves = cve_data["cve_ids"]
     if not cves:
         click.echo("No CVEs found...")
         return


### PR DESCRIPTION
CVE Services 1.1.0 will by default paginate responses that include more than 500 results.

Related API endpoint and its properties: https://github.com/CVEProject/cve-services/blob/release/v1.1.0/docs/openapi.yml#L604-L630

See also: https://github.com/CVEProject/cve-services/wiki/v1.1.0-Addendum-for-The-Developer-Guide-to-the-CVE-Services#update-to-get-cve-id-endpoint

