### PR TITLE
Add user registry support

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -146,17 +146,21 @@ class Config:
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
-    "-u", "--username", envvar="CVE_USER", required=True, help="User name (env var: CVE_USER)"
+    "-u", "--username", envvar="CVE_USER", required=True, help="Your username (env var: CVE_USER)"
 )
 @click.option(
     "-o",
     "--org",
     envvar="CVE_ORG",
     required=True,
-    help="CNA organization short name (env var: CVE_ORG)",
+    help="Your CNA organization short name (env var: CVE_ORG)",
 )
 @click.option(
-    "-a", "--api-key", envvar="CVE_API_KEY", required=True, help="API key (env var: CVE_API_KEY)"
+    "-a",
+    "--api-key",
+    envvar="CVE_API_KEY",
+    required=True,
+    help="Your API key (env var: CVE_API_KEY)",
 )
 @click.option(
     "-e",
@@ -381,8 +385,8 @@ def show_user(ctx, username, print_raw):
     "-u",
     "--username",
     default="",
-    help="Specify the user whose API token should be reset.",
-    show_default="Current user specified in -u/--username/CVE_USER",
+    help="User whose API token should be reset (only ADMIN role users can update other users).",
+    show_default="Current user specified in global -u/--username/CVE_USER",
 )
 @click.option("--raw", "print_raw", default=False, is_flag=True, help="Print response JSON.")
 @click.pass_context
@@ -414,7 +418,7 @@ def reset_token(ctx, username, print_raw):
     "--username",
     default="",
     required=True,
-    help="Username of the user being updated.",
+    help="Username of the user being updated (only ADMIN role users can update other users).",
     show_default="Current user specified in global -u/--username/CVE_USER",
 )
 @click.option(
@@ -484,6 +488,8 @@ def update_user(ctx, username, **opts_data):
 @handle_cve_api_error
 def create_user(ctx, username, name_first, name_last, roles, print_raw):
     """Create a user in your organization.
+
+    This action is restricted to users with the ADMIN role.
 
     Note: Once a user is created, they cannot be removed, only marked as inactive. Only create
     users when you really need them.

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -14,6 +14,7 @@ class CveApi:
         "prod": "https://cveawg.mitre.org/api/",
         "dev": "https://cveawg-dev.mitre.org/api/",
     }
+    USER_ROLES = ("ADMIN",)
 
     def __init__(self, username, org, api_key, env="prod", url=None):
         self.username = username
@@ -82,6 +83,9 @@ class CveApi:
     def post(self, path, **kwargs):
         return self.http_request("post", path, **kwargs)
 
+    def put(self, path, **kwargs):
+        return self.http_request("put", path, **kwargs)
+
     def reserve(self, count, random, year):
         """Reserve a set of CVE IDs.
 
@@ -119,6 +123,24 @@ class CveApi:
 
     def quota(self):
         return self.get(f"org/{self.org}/id_quota").json()
+
+    def show_user(self, username):
+        return self.get(f"org/{self.org}/user/{username}").json()
+
+    def reset_api_token(self, username):
+        return self.put(f"org/{self.org}/user/{username}/reset_secret").json()
+
+    def create_user(self, **user_data):
+        return self.post(f"org/{self.org}/user", json=user_data).json()
+
+    def update_user(self, username, **user_data):
+        return self.put(f"org/{self.org}/user/{username}", params=user_data).json()
+
+    def list_users(self):
+        return self.get_paged(f"org/{self.org}/users", page_data_attr="users", params={})
+
+    def show_org(self):
+        return self.get(f"org/{self.org}").json()
 
     def ping(self):
         """Check the CVE API status.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,3 +140,126 @@ def test_reserve():
             "\n"
             "Remaining quota: 10\n"
         )
+
+
+def test_active_user_show():
+    user_data = {
+        "UUID": "ac821fed-cbfa-47ab-bcde-822d759c7902",
+        "active": True,
+        "authority": {"active_roles": ["ADMIN"]},
+        "name": {
+            "first": "Test",
+            "last": "User",
+        },
+        "org_UUID": "304d44d8-3dd1-475d-83c1-5cbefb92b780",
+        "time": {"created": "2021-04-22T02:09:08.823Z", "modified": "2021-04-22T02:09:08.823Z"},
+        "username": "test@user",
+    }
+    with mock.patch("cvelib.cli.CveApi.show_user") as show_user:
+        show_user.return_value = user_data
+        runner = CliRunner()
+        result = runner.invoke(cli, DEFAULT_OPTS + ["user"])
+        assert result.exit_code == 0, result.output
+        assert result.output == (
+            "Test User — test@user\n"
+            "├─ Active:\tYes\n"
+            "├─ Roles:\tADMIN\n"
+            "├─ Created:\tThu Apr 22 02:09:08 2021\n"
+            "└─ Modified:\tThu Apr 22 02:09:08 2021\n"
+        )
+
+
+def test_inactive_user_show():
+    user_data = {
+        "UUID": "ac821fed-cbfa-47ab-bcde-822d759c7902",
+        "active": False,
+        "authority": {"active_roles": []},
+        "name": {
+            "first": "",
+            "last": "",
+        },
+        "org_UUID": "304d44d8-3dd1-475d-83c1-5cbefb92b780",
+        "time": {"created": "2021-04-22T02:09:08.823Z", "modified": "2021-04-22T02:09:08.823Z"},
+        "username": "test@user",
+    }
+    with mock.patch("cvelib.cli.CveApi.show_user") as show_user:
+        show_user.return_value = user_data
+        runner = CliRunner()
+        result = runner.invoke(cli, DEFAULT_OPTS + ["user"])
+        assert result.exit_code == 0, result.output
+        assert result.output == (
+            "test@user\n"
+            "├─ Active:\tNo\n"
+            "├─ Roles:\tNone\n"
+            "├─ Created:\tThu Apr 22 02:09:08 2021\n"
+            "└─ Modified:\tThu Apr 22 02:09:08 2021\n"
+        )
+
+
+def test_reset_token():
+    api_token = {"API-secret": "foo-token"}
+    with mock.patch("cvelib.cli.CveApi.reset_api_token") as reset_api_token:
+        reset_api_token.return_value = api_token
+        runner = CliRunner()
+        result = runner.invoke(cli, DEFAULT_OPTS + ["user", "reset-token"])
+        assert result.exit_code == 0, result.output
+        assert result.output == (
+            "New API token for test_user:\n\n"
+            "foo-token\n\n"
+            "Make sure to copy your new API token; you won't be able to access it again!\n"
+        )
+
+
+def test_user_list():
+    users = [
+        {
+            "UUID": "fe12571e-4a47-4272-9cc4-c61802c05356",
+            "active": True,
+            "authority": {"active_roles": ["ADMIN"]},
+            "name": {"first": "Hello", "last": "World"},
+            "org_UUID": "19f229d4-f3d5-4605-bf93-521fa4499c06",
+            "time": {"created": "2021-05-26T19:27:44.567Z", "modified": "2021-05-26T19:28:52.766Z"},
+            "username": "hello@world",
+        },
+        {
+            "UUID": "cb55b254-cf8f-46f6-bfbf-fc1d71ba439a",
+            "active": False,
+            "authority": {"active_roles": []},
+            "name": {"first": "Foo"},
+            "org_UUID": "19f229d4-f3d5-4605-bf93-521fa4499c06",
+            "time": {"created": "2021-05-26T19:27:24.366Z", "modified": "2021-05-26T19:32:57.857Z"},
+            "username": "foo",
+        },
+    ]
+    with mock.patch("cvelib.cli.CveApi.list_users") as list_users:
+        list_users.return_value = users
+        runner = CliRunner()
+        result = runner.invoke(cli, DEFAULT_OPTS + ["org", "users"])
+        assert result.exit_code == 0, result.output
+        assert result.output == (
+            "USERNAME      NAME          ROLES   ACTIVE   CREATED                    MODIFIED\n"
+            "foo           Foo           None    No       Wed May 26 19:27:24 2021   Wed May 26 19:32:57 2021\n"
+            "hello@world   Hello World   ADMIN   Yes      Wed May 26 19:27:44 2021   Wed May 26 19:28:52 2021\n"
+        )
+
+
+def test_show_org():
+    org = {
+        "UUID": "19f229d4-f3d5-4605-bf93-521fa4499c06",
+        "authority": {"active_roles": ["CNA"]},
+        "name": "Test Org",
+        "policies": {"id_quota": 1000},
+        "short_name": "test_org",
+        "time": {"created": "2021-04-21T02:09:07.389Z", "modified": "2021-04-21T02:09:07.389Z"},
+    }
+    with mock.patch("cvelib.cli.CveApi.show_org") as show_org:
+        show_org.return_value = org
+        runner = CliRunner()
+        result = runner.invoke(cli, DEFAULT_OPTS + ["org"])
+        assert result.exit_code == 0, result.output
+        assert result.output == (
+            "Test Org — test_org\n"
+            "├─ Roles:\tCNA\n"
+            "├─ Created:\tWed Apr 21 02:09:07 2021\n"
+            "└─ Modified:\tWed Apr 21 02:09:07 2021\n"
+        )


### PR DESCRIPTION
This change adds new commands to interact with new User Registry
functionality being released in CVE Services 1.1.0. Specifically:

- Create and update users
- Refresh user API tokens
- Viewing general information about your organization
- Listing users in your organization