### PR TITLE
Fix CVE states

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -284,7 +284,7 @@ def show_cve(ctx, print_raw, cve_id):
 @click.option("--year", callback=validate_year, help="Filter by year.")
 @click.option(
     "--state",
-    type=click.Choice(["reserved", "public", "reject"], case_sensitive=False),
+    type=click.Choice(["reserved", "published", "rejected"], case_sensitive=False),
     help="Filter by reservation state.",
 )
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_cve_list():
             "owning_cna": "acme",
             "requested_by": {"cna": "acme", "user": "ann"},
             "reserved": "2021-01-14T18:32:57.955Z",
-            "state": "PUBLIC",
+            "state": "PUBLISHED",
             "time": {
                 "created": "2021-01-14T18:32:57.956Z",
                 "modified": "2021-01-14T18:32:57.956Z",
@@ -63,7 +63,7 @@ def test_cve_list():
             "owning_cna": "acme",
             "requested_by": {"cna": "corp", "user": "eve"},
             "reserved": "2021-01-14T18:34:50.916Z",
-            "state": "REJECT",
+            "state": "REJECTED",
             "time": {
                 "created": "2021-01-14T18:34:50.917Z",
                 "modified": "2021-01-14T18:34:50.917Z",
@@ -76,10 +76,10 @@ def test_cve_list():
         result = runner.invoke(cli, DEFAULT_OPTS + ["list"])
         assert result.exit_code == 0, result.output
         assert result.output == (
-            "CVE ID          STATE      OWNING CNA   REQUESTED BY   RESERVED\n"
-            "CVE-2021-3001   RESERVED   acme         bob (acme)     Thu Jan 14 18:32:19 2021\n"
-            "CVE-2021-3002   PUBLIC     acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
-            "CVE-2021-3003   REJECT     acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
+            "CVE ID          STATE       OWNING CNA   REQUESTED BY   RESERVED\n"
+            "CVE-2021-3001   RESERVED    acme         bob (acme)     Thu Jan 14 18:32:19 2021\n"
+            "CVE-2021-3002   PUBLISHED   acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
+            "CVE-2021-3003   REJECTED    acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
         )
 
 


### PR DESCRIPTION
This PR fixes the CVE states:
- PUBLIC -> PUBLISHED;
- REJECT -> REJECTED

to be inline with the API specification.

This was discovered while issuing `cve list --state ...`.

Thanks for the client BTW!