### PR TITLE
CVE_ENVIRONMENT can be `test` but not `dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Additional options that have an accompanying environment variable include:
 
 * `-e/--environment` or `CVE_ENVIRONMENT`: allows you to configure the deployment environment
   (that is, the URL at which the service is available) to interface with. Allowed values: `prod`,
-  `dev`.
+  `test`.
 
 * `--api-url` or `CVE_API_URL`: allows you to override the URL for the CVE API that would
   otherwise be determined by the deployment environment you selected. This is useful for local

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Additional options that have an accompanying environment variable include:
 
 * `-e/--environment` or `CVE_ENVIRONMENT`: allows you to configure the deployment environment
   (that is, the URL at which the service is available) to interface with. Allowed values: `prod`,
-  `test`.
+  `test`, and `dev`. Separate credentials are required for each environment. The `test` and `dev`
+  environments may not be consistenly available as the CVE backend services are still in development.
 
 * `--api-url` or `CVE_API_URL`: allows you to override the URL for the CVE API that would
   otherwise be determined by the deployment environment you selected. This is useful for local


### PR DESCRIPTION
```
$ CVE_ENVIRONMENT=test cve org users
USERNAME           NAME         ROLES   ACTIVE   CREATED                    MODIFIED
amanion@cert.org   Art Manion   ADMIN   Yes      Wed Feb  2 21:18:04 2022   Wed Feb  2 21:18:04 2022

$ CVE_ENVIRONMENT=dev cve org users
ERROR: 401 Client Error: Unauthorized for url: https://cveawg-dev.mitre.org/api/org/certcc/users
DETAILS: {'error': 'UNAUTHORIZED', 'message': 'Unauthorized'}
```