### PR TITLE
Rename `create` to `publish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Reserve three non-sequential CVE IDs for a specific year:
 cve reserve 3 --year 2021 --random
 ```
 
-Create a CVE record for an already-reserved CVE ID like CVE-2022-1234:
+Publish a CVE record for an already-reserved CVE ID:
 
 ```
-cve create 'CVE-2022-1234' --json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
+cve publish 'CVE-2022-1234' --json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
 ```
 
-See the tests for an example of these required properties, or the JSON schema for all available properties:
-https://github.com/CVEProject/cve-services/blob/dev/src/controller/cve.controller/cna_container_schema.json
+For information on the required properties in a given CVE JSON record, see the `cnaPublishedContainer` schema in:
+https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json.
 
 List all rejected CVEs for year 2018:
 

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -50,7 +50,7 @@ def print_reserved_cve(cve):
         click.echo(f"└─ Owning CNA:\t{cve['owning_cna']}")
 
 
-def print_created_cve(cve):
+def print_published_cve(cve):
     click.secho(cve["cveMetadata"]["cveId"], bold=True)
     click.echo(f"├─ State:\t{cve['cveMetadata']['state']}")
     click.echo(f"├─ Owning CNA:\t{cve['cveMetadata']['assignerShortName']}")
@@ -208,19 +208,23 @@ def cli(ctx, username, org, api_key, env, api_url, interactive):
     "cve_json_str",
     required=True,
     type=click.STRING,
-    help="JSON body of CVE record to create.",
+    help="JSON body of CVE record to publish.",
 )
 @click.option("--raw", "print_raw", default=False, is_flag=True, help="Print response JSON.")
 @click.pass_context
 @handle_cve_api_error
-def create(ctx, cve_id, cve_json_str, print_raw):
-    """Create a CVE record for an already-reserved CVE ID like CVE-2022-1234.
-    Will not update if the CVE already exists.
+def publish(ctx, cve_id, cve_json_str, print_raw):
+    """Publish a CVE record for an already-reserved CVE ID.
 
-    cve create 'CVE-2022-1234' --json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
+    Will not update if the CVE record is already published.
 
-    See the tests for an example of these required properties, or the JSON schema for all available properties:
-    https://github.com/CVEProject/cve-services/blob/dev/src/controller/cve.controller/cna_container_schema.json
+    \b
+    cve publish 'CVE-2022-1234' --json \\
+    '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
+
+    For information on the required properties in a given CVE JSON record, see the
+    `cnaPublishedContainer` schema in:\n
+    https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
     """
     try:
         cve_json = json.loads(cve_json_str)
@@ -229,7 +233,7 @@ def create(ctx, cve_id, cve_json_str, print_raw):
         click.secho(e)
         return
     if ctx.obj.interactive:
-        click.echo("You are about to create a CVE record for ", nl=False)
+        click.echo("You are about to publish a CVE record for ", nl=False)
         click.secho(cve_id, bold=True, nl=False)
         click.echo(" from the following input:\n\n", nl=False)
         click.secho(cve_json_str, bold=True, nl=False)
@@ -239,12 +243,12 @@ def create(ctx, cve_id, cve_json_str, print_raw):
         click.echo()
 
     cve_api = ctx.obj.cve_api
-    response_data = cve_api.create(cve_id, cve_json)
+    response_data = cve_api.publish(cve_id, cve_json)
     if print_raw:
         print_json_data(response_data)
     else:
-        click.echo("Created the following CVE:\n")
-        print_created_cve(response_data["created"])
+        click.echo("Published the following CVE:\n")
+        print_published_cve(response_data["created"])
 
 
 @cli.command()

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -97,7 +97,8 @@ class CveApi:
     def reserve(self, count, random, year):
         """Reserve a set of CVE IDs.
 
-        This method returns a tuple containing the reserved CVE IDs, and the remaining ID quota left over.
+        This method returns a tuple containing the reserved CVE IDs, and the remaining ID quota
+        left over.
         """
         params = {
             "cve_year": year,

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -87,9 +87,8 @@ class CveApi:
     def put(self, path, **kwargs):
         return self.http_request("put", path, **kwargs)
 
-    def create(self, cve_id, cve_json):
-        """Create a CVE from a JSON object representing the CNA container data."""
-        # Wrap the container data due to an API change
+    def publish(self, cve_id, cve_json):
+        """Publish a CVE from a JSON object representing the CNA container data."""
         cve_json = {"cnaContainer": cve_json}
         response = self.post(f"cve/{cve_id}/cna", json=cve_json)
         response.raise_for_status()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,13 +134,13 @@ def test_cve_create():
     cna_text = json.dumps(cna_dict)
     response_dict = {"created": cve_dict, "message": f"{cve_id} record was successfully created."}
 
-    with mock.patch("cvelib.cli.CveApi.create") as create:
-        create.return_value = response_dict
+    with mock.patch("cvelib.cli.CveApi.publish") as publish:
+        publish.return_value = response_dict
         runner = CliRunner()
-        result = runner.invoke(cli, DEFAULT_OPTS + ["create", cve_id, "--json", cna_text])
+        result = runner.invoke(cli, DEFAULT_OPTS + ["publish", cve_id, "--json", cna_text])
         assert result.exit_code == 0, result.output
         assert result.output == (
-            "Created the following CVE:\n"
+            "Published the following CVE:\n"
             "\n"
             f"{cve_id}\n"
             "├─ State:\tPUBLISHED\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,8 +307,10 @@ def test_user_list():
         assert result.exit_code == 0, result.output
         assert result.output == (
             "USERNAME      NAME          ROLES   ACTIVE   CREATED                    MODIFIED\n"
-            "foo           Foo           None    No       Wed May 26 19:27:24 2021   Wed May 26 19:32:57 2021\n"
-            "hello@world   Hello World   ADMIN   Yes      Wed May 26 19:27:44 2021   Wed May 26 19:28:52 2021\n"
+            "foo           Foo           None    No       Wed May 26 19:27:24 2021   "
+            "Wed May 26 19:32:57 2021\n"
+            "hello@world   Hello World   ADMIN   Yes      Wed May 26 19:27:44 2021   "
+            "Wed May 26 19:28:52 2021\n"
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,11 @@ commands = isort --check --diff .
 # W504: line break after binary operator
 # W503: line break before binary operator (used by black formatter)
 # E203: whitespace before ':' (used by black formatter)
-# E501: line too long (black enforces 100 for code; don't care elsewhere)
 #
 # TODO: move config to pyproject.toml after https://github.com/PyCQA/flake8/issues/234 is resolved.
-ignore = W504,W503,E203,E501
+ignore = W504,W503,E203
+# Keep in sync with black.line-length in pyproject.toml
+max-line-length = 100
 exclude = .git/,venv/,.tox/,build/
 
 [testenv:flake8]


### PR DESCRIPTION
This more aligns with the wording used within the community and also
matches the expectation of a CVE ID reservation being moved from its
"reserved" state to the "published" state.