### PR TITLE
PUBLISHED and REJECTED

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A library and a command line interface for the CVE Services API.
 
+**NOTE: Changes for the upcoming release of CVE Services 2.1.0 are tracked in the
+[`cve-services-2.1.0`](https://github.com/RedHatProductSecurity/cvelib/tree/cve-services-2.1.0) branch.
+Code on the [`master`](https://github.com/RedHatProductSecurity/cvelib/tree/master) branch, also included in 
+the latest released PyPI package and the cvelib container image, are compatible with the currently-available CVE 
+Services 1.1.1 running at https://cveawg.mitre.org/api/.**
+
 ## Requirements
 
 - Python version 3.6 or greater

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ cve reserve 3 --year 2021 --random
 List all rejected CVEs for year 2018:
 
 ```
-cve list --year 2018 --state reject
+cve list --year 2018 --state rejected
 ```
 
 Assuming you have the `ADMIN` role (also called an _Org Admin_), create a new user in your

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -306,7 +306,7 @@ def show_cve(ctx: click.Context, print_raw: bool, cve_id: str) -> None:
 @click.option("--year", callback=validate_year, help="Filter by year.")
 @click.option(
     "--state",
-    type=click.Choice(["reserved", "public", "reject"], case_sensitive=False),
+    type=click.Choice(["reserved", "published", "rejected"], case_sensitive=False),
     help="Filter by reservation state.",
 )
 @click.option(

--- a/man/cve-list.1
+++ b/man/cve-list.1
@@ -17,7 +17,7 @@ Sort output.
 \fB\-\-year\fP TEXT
 Filter by year.
 .TP
-\fB\-\-state\fP [reserved|public|reject]
+\fB\-\-state\fP [reserved|published|rejected]
 Filter by reservation state.
 .TP
 \fB\-\-reserved\-lt\fP [%Y\-%m\-%d|%Y\-%m\-%dT%H:%M:%S|%Y\-%m\-%d %H:%M:%S]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_cve_list():
             "owning_cna": "acme",
             "requested_by": {"cna": "acme", "user": "ann"},
             "reserved": "2021-01-14T18:32:57.955Z",
-            "state": "PUBLIC",
+            "state": "PUBLISHED",
             "time": {
                 "created": "2021-01-14T18:32:57.956Z",
                 "modified": "2021-01-14T18:32:57.956Z",
@@ -63,7 +63,7 @@ def test_cve_list():
             "owning_cna": "acme",
             "requested_by": {"cna": "corp", "user": "eve"},
             "reserved": "2021-01-14T18:34:50.916Z",
-            "state": "REJECT",
+            "state": "REJECTED",
             "time": {
                 "created": "2021-01-14T18:34:50.917Z",
                 "modified": "2021-01-14T18:34:50.917Z",
@@ -78,8 +78,8 @@ def test_cve_list():
         assert result.output == (
             "CVE ID          STATE      OWNING CNA   REQUESTED BY   RESERVED\n"
             "CVE-2021-3001   RESERVED   acme         bob (acme)     Thu Jan 14 18:32:19 2021\n"
-            "CVE-2021-3002   PUBLIC     acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
-            "CVE-2021-3003   REJECT     acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
+            "CVE-2021-3002   PUBLISHED  acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
+            "CVE-2021-3003   REJECTED   acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,10 +76,10 @@ def test_cve_list():
         result = runner.invoke(cli, DEFAULT_OPTS + ["list"])
         assert result.exit_code == 0, result.output
         assert result.output == (
-            "CVE ID          STATE      OWNING CNA   REQUESTED BY   RESERVED\n"
-            "CVE-2021-3001   RESERVED   acme         bob (acme)     Thu Jan 14 18:32:19 2021\n"
-            "CVE-2021-3002   PUBLISHED  acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
-            "CVE-2021-3003   REJECTED   acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
+            "CVE ID          STATE       OWNING CNA   REQUESTED BY   RESERVED\n"
+            "CVE-2021-3001   RESERVED    acme         bob (acme)     Thu Jan 14 18:32:19 2021\n"
+            "CVE-2021-3002   PUBLISHED   acme         ann (acme)     Thu Jan 14 18:32:57 2021\n"
+            "CVE-2021-3003   REJECTED    acme         eve (corp)     Thu Jan 14 18:34:50 2021\n"
         )
 
 


### PR DESCRIPTION
CVE Services 2.1 recently(?) changed state text PUBLIC-->PUBLISHED and REJECT-->REJECTED.

I'm testing cvelib and some other clients in advance of the October transition and a virtual workshop on 11/2.