### PR TITLE
Show CVE record

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -396,16 +396,16 @@ def reserve(ctx: click.Context, random: bool, year: str, count: int, print_raw: 
         click.echo()
 
     cve_api = ctx.obj.cve_api
-    cve_data, remaining_quota = cve_api.reserve(count, random, year)
+    cve_data = cve_api.reserve(count, random, year)
     if print_raw:
         print_json_data(cve_data)
         return
 
     click.echo("Reserved the following CVE ID(s):\n")
-    for cve in cve_data["cve_ids"]:
-        print_reserved_cve(cve)
+    for cve_id_data in cve_data["cve_ids"]:
+        print_cve_id(cve_id_data)
 
-    click.echo(f"\nRemaining quota: {remaining_quota}")
+    click.echo(f"\nRemaining quota: {cve_data['meta']['remaining_quota']}")
 
 
 @cli.command(name="show")

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -113,8 +113,11 @@ class CveApi:
             params["batch_type"] = "nonsequential" if random else "sequential"
         return self._post("cve-id", params=params).json()
 
-    def show_cve(self, cve_id: str) -> dict:
+    def show_cve_id(self, cve_id: str) -> dict:
         return self._get(f"cve-id/{cve_id}").json()
+
+    def show_cve_record(self, cve_id: str) -> dict:
+        return self._get(f"cve/{cve_id}").json()
 
     def list_cves(
         self,

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -99,11 +99,10 @@ class CveApi:
         response.raise_for_status()
         return response.json()
 
-    def reserve(self, count: int, random: bool, year: str) -> Tuple[dict, str]:
+    def reserve(self, count: int, random: bool, year: str) -> dict:
         """Reserve a set of CVE IDs.
 
-        This method returns a tuple containing the reserved CVE IDs, and the remaining ID quota
-        left over.
+        The return object contains the reserved CVE IDs and the remaining CVE ID quota.
         """
         params = {
             "cve_year": year,
@@ -112,9 +111,7 @@ class CveApi:
         }
         if count > 1:
             params["batch_type"] = "nonsequential" if random else "sequential"
-        response = self._post("cve-id", params=params)
-        data = response.json()
-        return data, data["meta"]["remaining_quota"]
+        return self._post("cve-id", params=params).json()
 
     def show_cve(self, cve_id: str) -> dict:
         return self._get(f"cve-id/{cve_id}").json()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,7 +236,7 @@ def test_reserve():
         },
     }
     with mock.patch("cvelib.cli.CveApi.reserve") as reserve:
-        reserve.return_value = reserved_cves, 10
+        reserve.return_value = reserved_cves
         runner = CliRunner()
         result = runner.invoke(cli, DEFAULT_OPTS + ["reserve", "-y", "2021", "2"])
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
This adds support for showing the CVE record for a specific CVE ID with a `--show-record` option.