### PR TITLE
Handle record-does-not-exist error when viewing a CVE ID reservation with `--show-record`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Services 1.1.1 running at https://cveawg.mitre.org/api/.**
 
 ### Linux, MacOS, Windows
 
-```
+```bash
 python3 -m pip install --user cvelib
 ```
 
@@ -34,7 +34,7 @@ Check the spelling of the name, or if a path was included, verify that the path 
 
 To resolve this error, add the file path for where your `cve.exe` file resides (for example,
 `C:\Users\<username>\AppData\Roaming\Python\Python39\Scripts`) to your `PATH` variable. You can
-edit your environment variables by searching *Edit the system environment variables*.
+edit your environment variables by searching *Edit the system environment variables* from the Start menu.
 
 ### Podman/Docker
 
@@ -42,8 +42,9 @@ You can fetch a specific version of the `cvelib` library installed in a containe
 https://quay.io/repository/prodsecdev/cvelib. You can set up an alias to run the `cve` command using this container
 image:
 
-```
+```bash
 alias cve='podman run -it --rm quay.io/prodsecdev/cvelib'
+# OR
 alias cve='docker run -it --rm quay.io/prodsecdev/cvelib'
 ```
 
@@ -57,7 +58,7 @@ the authentication details with every command (using options `-u/--username`, `-
 
 ### Linux & MacOS
 
-```
+```bash
 $ export CVE_USER=margo
 $ export CVE_ORG=acme
 $ export CVE_API_KEY=<api_key>
@@ -91,14 +92,14 @@ CVE_API_KEY=<api_key>
 
 Then, specify that file in your Podman/Docker command, for example:
 
-```
+```bash
 podman run -it --rm --env-file=.env quay.io/prodsecdev/cvelib ping
 ```
 
 Alternatively, you can set the environment variables as shown in the sections above and pass them to the container
 using:
 
-```
+```bash
 podman run -it --rm -e CVE_ORG -e CVE_API_KEY -e CVE_USER quay.io/prodsecdev/cvelib ping
 ```
 
@@ -107,37 +108,39 @@ podman run -it --rm -e CVE_ORG -e CVE_API_KEY -e CVE_USER quay.io/prodsecdev/cve
 Additional options that have an accompanying environment variable include:
 
 * `-e/--environment` or `CVE_ENVIRONMENT`: allows you to configure the deployment environment
-  (that is, the URL at which the service is available) to interface with. Allowed values: `prod`,
+  (that is, the URL at which the CVE Services is available) to interface with. Allowed values: `prod`,
   `test`, and `dev`. Separate credentials are required for each environment. The `test` and `dev`
-  environments may not be consistenly available as the CVE backend services are still in development.
+  environments may not be consistently available during the development life cycle of CVE Services.
 
-* `--api-url` or `CVE_API_URL`: allows you to override the URL for the CVE API that would
+* `--api-url` or `CVE_API_URL`: allows you to override the URL for the CVE Services API that would
   otherwise be determined by the deployment environment you selected. This is useful for local
-  testing to point to a CVE API instance running on localhost.
+  testing to point to a CVE Services API instance running on localhost (for example,
+  `export CVE_API_URL=http://localhost:3000/api/).
 
 * `-i/--interactive` or `CVE_INTERACTIVE`: every create/update action will require confirmation
-  before a request is sent. 
+  before a request is sent to CVE Services. Truthy values for the environment variable are:
+  `1`, `t`, `yes`.
 
-## CLI Usage
+## CLI Usage Examples
 
 Available options and commands can be displayed by running `cve --help`. The following are
 examples of some commonly used operations.
 
 Reserve one CVE ID in the current year (you will be prompted to confirm your action):
 
-```
+```bash
 cve --interactive reserve
 ```
 
 Reserve three non-sequential CVE IDs for a specific year:
 
-```
+```bash
 cve reserve 3 --year 2021 --random
 ```
 
 Publish a CVE record for an already-reserved CVE ID:
 
-```
+```bash
 cve publish 'CVE-2022-1234' --json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
 ```
 
@@ -146,32 +149,32 @@ https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_sc
 
 List all rejected CVEs for year 2018:
 
-```
+```bash
 cve list --year 2018 --state reject
 ```
 
 Assuming you have the `ADMIN` role (also called an _Org Admin_), create a new user in your
 organization with:
 
-```
+```bash
 cve user create -u foo@bar.com --name-first Foo --name-last Bar
 ```
 
 Mark a user as inactive (again, assuming you have the `ADMIN` role):
 
-```
+```bash
 cve user update -u foo@bar.com --mark-inactive
 ```
 
 Reset your own API key:
 
-```
+```bash
 cve user reset-key
 ```
 
 List all users in your organization:
 
-```
+```bash
 cve org users
 ```
 
@@ -179,10 +182,11 @@ See `-h/--help` of any command for a complete list of sub-commands and options.
 
 ## Other CVE Services Clients
 
-- Client-side library for the CVE API written in JavaScript: https://github.com/xdrr/cve.js
+- Client-side library written in JavaScript: https://github.com/xdrr/cve.js
 - A web-based client interface and a client library in JavaScript: https://github.com/CERTCC/cveClient
-- A web-based tool for creating and editing CVE records in the CVE JSON format: https://github.com/Vulnogram/Vulnogram
-  - Hosted instance available at: https://vulnogram.github.io/#editor
+- A web-based tool for creating and editing CVE records in the CVE JSON v5 format:
+  https://github.com/Vulnogram/Vulnogram
+  - A hosted instance is available at: https://vulnogram.github.io/#editor
 
 ## Development Setup
 
@@ -194,6 +198,8 @@ source venv/bin/activate
 pip install --upgrade pip
 pip install -e .
 pip install tox
+# If you want to use any of the dev dependencies outside of Tox, you can install them all with:
+pip install -e .[dev]
 ```
 
 This project uses the [Black](https://black.readthedocs.io) code formatter. To reformat the entire
@@ -205,7 +211,15 @@ pip install black
 black .
 ```
 
-Running tests:
+To sort all imports using [isort](https://pycqa.github.io/isort/), run:
+
+```bash
+# Sort all imports
+pip install isort
+isort .
+```
+
+Running tests and linters (`flake8`, `mypy`, and `isort`/`black` formatting checks):
 
 ```bash
 # Run all tests and format check (also run as a Github action)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ podman run -it --rm -e CVE_ORG -e CVE_API_KEY -e CVE_USER quay.io/prodsecdev/cve
 Additional options that have an accompanying environment variable include:
 
 * `-e/--environment` or `CVE_ENVIRONMENT`: allows you to configure the deployment environment
-  (that is, the URL at which the CVE Services is available) to interface with. Allowed values: `prod`,
+  (that is, the URL at which CVE Services is available) to interface with. Allowed values: `prod`,
   `test`, and `dev`. Separate credentials are required for each environment. The `test` and `dev`
   environments may not be consistently available during the development life cycle of CVE Services.
 

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -435,11 +435,16 @@ def show_cve(ctx: click.Context, show_record: bool, print_raw: bool, cve_id: str
                 raise exc
 
     if print_raw:
-        print_json_data(cve_id_data)
+        # Serialize the CVE ID data and CVE record into an array for easier parsing if we're
+        # showing the record as well. If not, just display the CVE ID data.
         if show_record:
-            print_json_data(cve_record_data)
+            print_json_data([cve_id_data, cve_record_data])
+        else:
+            print_json_data(cve_id_data)
     else:
         print_cve_id(cve_id_data)
+        # If we're showing the CVE record, display it as either the raw JSON if it exists or show
+        # an informational message if it does not.
         if show_record:
             click.secho("-----", bold=True)
             if cve_record_data:

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -445,7 +445,7 @@ def show_cve(ctx: click.Context, show_record: bool, print_raw: bool, cve_id: str
             if cve_record_data:
                 print_json_data(cve_record_data)
             else:
-                click.echo("CVE record does not exists.")
+                click.echo("CVE record does not exist.")
 
 
 @cli.command(name="list")

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -226,7 +226,7 @@ def cli(
 
 
 @cli.command()
-@click.argument("cve_id", type=click.STRING)
+@click.argument("cve_id", callback=validate_cve)
 @click.option(
     "--json",
     "cve_json_str",
@@ -284,7 +284,7 @@ def publish(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool)
 
 
 @cli.command()
-@click.argument("cve_id", type=click.STRING)
+@click.argument("cve_id", callback=validate_cve)
 @click.option(
     "--json",
     "cve_json_str",

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -11,8 +11,12 @@ class CveApi:
         "dev": "https://cveawg-dev.mitre.org/api/",
         "test": "https://cveawg-test.mitre.org/api/",
     }
-    RECORD_EXISTS = "CVE_RECORD_EXISTS"
+
     USER_ROLES = ("ADMIN",)
+
+    class Errors:
+        RECORD_EXISTS = "CVE_RECORD_EXISTS"
+        RECORD_DOES_NOT_EXIST = "CVE_RECORD_DNE"
 
     def __init__(
         self, username: str, org: str, api_key: str, env: str = "prod", url: Optional[str] = None


### PR DESCRIPTION
\+ some docs improvements and missing CVE ID validation.