### PR TITLE
Add a few missing state transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cve reserve 3 --year 2021 --random
 Publish a CVE record for an already-reserved CVE ID:
 
 ```bash
-cve publish 'CVE-2022-1234' --json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
+cve publish CVE-2022-1234 --cve-json '{"affected": [], "descriptions": [], "providerMetadata": {}, "references": []}'
 ```
 
 For information on the required properties in a given CVE JSON record, see the `cnaPublishedContainer` schema in:


### PR DESCRIPTION
This adds support for moving CVE IDs to rejected without a CVE record as well as moving such rejected IDs back to reserved. For lack of a better action name, the subcommand is called undo-reject since the only transition it supports is moving a rejected w/o record ID to reserved (which too has no record).

This also adds a convenience Constants enum to use when we need lists of constant values.

Misc improvements to docs and options as well.