### PR TITLE
Allow loading CVE records from a file

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -4,7 +4,7 @@ import sys
 from collections import defaultdict
 from datetime import date, datetime
 from functools import wraps
-from typing import Any, Callable, DefaultDict, List, Optional, Sequence, Union
+from typing import Any, Callable, DefaultDict, List, Optional, Sequence, TextIO, Union
 
 import click
 import requests
@@ -128,15 +128,18 @@ def handle_cve_api_error(func: Callable) -> Callable:
                     details = exc.response.json()
                 except ValueError:
                     details = exc.response.content
-
-        click.secho("ERROR: ", bold=True, nl=False)
-        click.echo(error)
-        if details:
-            click.secho("DETAILS: ", bold=True, nl=False)
-            click.echo(details)
+            print_error(error, details)
         sys.exit(1)
 
     return wrapped
+
+
+def print_error(msg: str, details: Optional[str]) -> None:
+    click.secho("ERROR: ", bold=True, nl=False)
+    click.echo(msg)
+    if details:
+        click.secho("DETAILS: ", bold=True, nl=False)
+        click.echo(details)
 
 
 class Config:
@@ -231,14 +234,25 @@ def cli(
     "-j",
     "--cve-json",
     "cve_json_str",
-    required=True,
     type=click.STRING,
     help="JSON body of CVE record to publish.",
+)
+@click.option(
+    "-f",
+    "--cve-json-file",
+    type=click.File(),
+    help="File containing JSON body of CVE record to publish.",
 )
 @click.option("--raw", "print_raw", default=False, is_flag=True, help="Print response JSON.")
 @click.pass_context
 @handle_cve_api_error
-def publish(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool) -> None:
+def publish(
+    ctx: click.Context,
+    cve_id: str,
+    cve_json_str: Optional[str],
+    cve_json_file: Optional[TextIO],
+    print_raw: bool,
+) -> None:
     """Publish a CVE record for a reserved (or rejected) CVE ID.
 
     If the CVE is already published, this action will update its record. A published CVE can only be
@@ -247,24 +261,36 @@ def publish(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool)
 
     Example:
 
-    \b
     cve publish CVE-2022-1234 -j '{"affected": [], "descriptions": [], "references": {}, ...}'
 
     For information on the required properties in a given CVE JSON record, see the
     `cnaPublishedContainer` schema in:\n
     https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
     """
+    if cve_json_file is not None and cve_json_str is not None:
+        raise click.BadParameter(
+            "cannot use both `-f/--cve-json-file` and `-j/--cve-json` to provide a CVE JSON record."
+        )
+
     try:
-        cve_json = json.loads(cve_json_str)
+        if cve_json_str is not None:
+            cve_json = json.loads(cve_json_str)
+        elif cve_json_file is not None:
+            cve_json = json.load(cve_json_file)
+        else:
+            raise click.BadParameter(
+                "must provide CVE JSON record using one of: "
+                "`-f/--cve-json-file` or `-j/--cve-json`."
+            )
     except json.JSONDecodeError as exc:
-        click.echo("CVE data was not valid JSON. Error was:\n")
-        click.secho(str(exc))
+        print_error(msg="CVE data is not valid JSON", details=str(exc))
         return
+
     if ctx.obj.interactive:
         click.echo("You are about to publish a CVE record for ", nl=False)
         click.secho(cve_id, bold=True, nl=False)
         click.echo(" using the following input:\n\n", nl=False)
-        click.secho(cve_json_str, bold=True, nl=False)
+        print_json_data(cve_json)
         if not click.confirm("\n\nDo you want to continue?"):
             click.echo("Exiting...")
             sys.exit(0)
@@ -296,10 +322,22 @@ def publish(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool)
     type=click.STRING,
     help="JSON body of CVE record to reject.",
 )
+@click.option(
+    "-f",
+    "--cve-json-file",
+    type=click.File(),
+    help="File containing JSON body of CVE record to reject.",
+)
 @click.option("--raw", "print_raw", default=False, is_flag=True, help="Print response JSON.")
 @click.pass_context
 @handle_cve_api_error
-def reject(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool) -> None:
+def reject(
+    ctx: click.Context,
+    cve_id: str,
+    cve_json_str: Optional[str],
+    cve_json_file: Optional[TextIO],
+    print_raw: bool,
+) -> None:
     """Reject a CVE record for a reserved or published CVE ID.
 
     If the CVE is already rejected, this action will update its record if one is supplied.
@@ -309,28 +347,34 @@ def reject(ctx: click.Context, cve_id: str, cve_json_str: str, print_raw: bool) 
 
     Example:
 
-    \b
     cve reject CVE-2022-1234 -j '{"rejectedReasons": [{"lang": "en", "value": "A reason."}]}'
 
     For information on the required properties in a given CVE JSON record, see the
     `cnaRejectedContainer` schema in:\n
     https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
     """
-    cve_json = None
-    if cve_json_str:
-        try:
+    if cve_json_file is not None and cve_json_str is not None:
+        raise click.BadParameter(
+            "cannot use both `-f/--cve-json-file` and `-j/--cve-json` to provide a CVE JSON record."
+        )
+
+    try:
+        if cve_json_str is not None:
             cve_json = json.loads(cve_json_str)
-        except json.JSONDecodeError as exc:
-            click.echo("CVE data was not valid JSON. Error was:\n")
-            click.secho(str(exc))
-            return
+        elif cve_json_file is not None:
+            cve_json = json.load(cve_json_file)
+        else:
+            cve_json = None
+    except json.JSONDecodeError as exc:
+        print_error(msg="CVE data is not valid JSON", details=str(exc))
+        return
 
     if ctx.obj.interactive:
         click.echo("You are about to reject ", nl=False)
         click.secho(cve_id, bold=True, nl=False)
-        if cve_json:
+        if cve_json is not None:
             click.echo(" using the following input:\n\n", nl=False)
-            click.secho(cve_json_str)
+            print_json_data(cve_json)
         else:
             click.echo(" without providing a reject record.")
         if not click.confirm("\nDo you want to continue?"):


### PR DESCRIPTION
This makes it easier to generate a record in e.g. Vulnogram, hit Download to save the record in a file, edit that file to pair it down to just the CNA container, and call `cve publish <CVE_ID> -f <FILE>`.

Resolves https://github.com/RedHatProductSecurity/cvelib/issues/18