### PR TITLE
Check if the "name" object is missing in "user" object

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -97,8 +97,12 @@ def print_user(user: dict) -> None:
 
 
 def get_full_name(user_data: dict) -> Optional[str]:
-    name_data = user_data["name"]
-    return f"{name_data.get('first', '')} {name_data.get('last', '')}".strip() or None
+    # If no name values are defined on a user, the entire `name` object is not returned in the
+    # user data response; see https://github.com/CVEProject/cve-services/issues/901.
+    name = user_data.get("name", {})
+    if name:
+        return f"{name.get('first', '')} {name.get('last', '')}".strip() or None
+    return None
 
 
 def bool_to_text(value: Optional[bool]) -> str:


### PR DESCRIPTION
This is essentially a revert of f466ad44 with a link to a new issue where this was reported again since it doesn't seem the original issue was actually fixed.

Resolves #40