### PR TITLE
Add schema validation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include *.md
+recursive-include tests/ *.py *.md *.json
+graft man
+graft cvelib/schemas
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -10,7 +10,7 @@ import click
 import requests
 
 from . import __version__
-from .cve_api import CveApi
+from .cve_api import CveApi, CveRecordValidationError
 
 CVE_RE = re.compile(r"^CVE-[12]\d{3}-\d{4,}$")
 CONTEXT_SETTINGS = {
@@ -133,6 +133,11 @@ def handle_cve_api_error(func: Callable) -> Callable:
                 except ValueError:
                     details = exc.response.content
             print_error(error, details)
+        except CveRecordValidationError as exc:
+            click.secho("ERROR: ", bold=True, nl=False)
+            click.echo("CVE record is not valid against the v5 JSON schema:")
+            for error in exc.errors:
+                click.echo(f"  {error}")
         sys.exit(1)
 
     return wrapped

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -77,7 +77,7 @@ def print_table(lines: Sequence[Sequence[str]]) -> None:
 
 
 def print_json_data(data: Union[dict, list]) -> None:
-    click.echo(json.dumps(data, indent=4, sort_keys=True))
+    click.echo(json.dumps(data, indent=2, sort_keys=True))
 
 
 def print_user(user: dict) -> None:

--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -268,13 +268,19 @@ def publish(
     moved to the rejected state with an appropriate reject record (see `cve reject`). A published
     CVE cannot be moved back to the reserved state.
 
-    Example:
+    The CVE record can be specified as a string:
 
-    cve publish CVE-2022-1234 -j '{"affected": [], "descriptions": [], "references": {}, ...}'
+      cve publish CVE-2022-1234 -j '{"affected": [], "descriptions": [], "references": {}, ...}'
 
-    For information on the required properties in a given CVE JSON record, see the
-    `cnaPublishedContainer` schema in:\n
+    Or passed in a file:
+
+      cve publish CVE-2022-1234 -f v5_record.json
+
+    For information on the required properties in a given CVE JSON record, see the schema in:\n
     https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
+
+    Because the CVE Services API only expects the cnaPublishedContainer contents of the full record,
+    the record you pass to this command can specify just that data, and not the full record.
     """
     if cve_json_file is not None and cve_json_str is not None:
         raise click.BadParameter(
@@ -354,13 +360,19 @@ def reject(
     A rejected CVE without a record can be moved to the reserved state. A published CVE can only
     be rejected with an accompanying record. Reserved CVEs can be rejected with or without a record.
 
-    Example:
+    The CVE reject record can be specified as a string:
 
-    cve reject CVE-2022-1234 -j '{"rejectedReasons": [{"lang": "en", "value": "A reason."}]}'
+      cve reject CVE-2022-1234 -j '{"rejectedReasons": [{"lang": "en", "value": "A reason."}]}'
 
-    For information on the required properties in a given CVE JSON record, see the
-    `cnaRejectedContainer` schema in:\n
+    Or passed in a file:
+
+      cve reject CVE-2022-1234 -f v5_reject_record.json
+
+    For information on the required properties in a given CVE JSON record, see the schema in:\n
     https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
+
+    Because the CVE Services API only expects the cnaRejectedContainer contents of the full record,
+    the record you pass to this command can specify just that data, and not the full record.
     """
     if cve_json_file is not None and cve_json_str is not None:
         raise click.BadParameter(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ dev_require = [
     "tox",
     "types-click",
     "types-requests",
+    "types-jsonschema",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,30 @@
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 
-requires = [
+install_requires = [
     "click>=7.1.2",
     "requests>=2.24.0",
+    "jsonschema>=4.17.0",
+]
+
+tests_require = [
+    "pytest",
+]
+
+dev_require = [
+    *tests_require,
+    "black",
+    "click-man",
+    "flake8",
+    "isort",
+    "mypy",
+    "tox",
+    "types-click",
+    "types-requests",
 ]
 
 extras_require = {
-    "dev": [
-        "black",
-        "click-man",
-        "flake8",
-        "isort",
-        "mypy",
-        "pytest",
-        "tox",
-        "types-click",
-        "types-requests",
-    ]
+    "dev": dev_require,
+    "test": tests_require,
 }
 
 with open("README.md") as f:
@@ -52,8 +60,8 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     include_package_data=True,
-    packages=["cvelib"],
-    install_requires=requires,
+    packages=find_namespace_packages(),
+    install_requires=install_requires,
     extras_require=extras_require,
     entry_points={
         "console_scripts": [

--- a/tests/data/CVEv5_advanced-example.json
+++ b/tests/data/CVEv5_advanced-example.json
@@ -1,0 +1,310 @@
+{
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0",
+  "cveMetadata": {
+    "cveId": "CVE-1337-1234",
+    "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+    "assignerShortName": "example",
+    "requesterUserId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+    "serial": 1,
+    "state": "PUBLISHED"
+  },
+  "containers": {
+    "cna": {
+      "providerMetadata": {
+        "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+        "shortName": "example",
+        "dateUpdated":  "2021-09-08T16:24:00.000Z"
+      },
+      "title": "Buffer overflow in Example Enterprise allows Privilege Escalation.",
+      "datePublic": "2021-09-08T16:24:00.000Z",
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "lang": "en",
+              "cweId": "CWE-78",
+              "description": "CWE-78 OS Command Injection",
+              "type": "CWE"
+            }
+          ]
+        }
+      ],
+      "impacts": [
+        {
+          "capecId": "CAPEC-233",
+          "descriptions": [
+            {
+              "lang": "en",
+              "value": "CAPEC-233 Privilege Escalation"
+            }
+          ]
+        }
+      ],
+      "affected": [
+        {
+          "vendor": "Example.org",
+          "product": "Example Enterprise",
+          "platforms": [
+            "Windows",
+            "MacOS",
+            "XT-4500"
+          ],
+          "collectionURL": "https://example.org/packages",
+          "packageName": "example_enterprise",
+          "repo": "git://example.org/source/example_enterprise",
+          "modules": [
+            "Web-Management-Interface"
+          ],
+          "programFiles": [
+            "example_enterprise/example.php"
+          ],
+          "programRoutines": [
+            {
+              "name": "parseFilename"
+            }
+          ],
+          "versions": [
+            {
+              "version": "1.0.0",
+              "status": "affected",
+              "lessThan": "1.0.6",
+              "versionType": "semver"
+            },
+            {
+              "version": "2.1.0",
+              "status": "unaffected",
+              "lessThan": "2.1.*",
+              "changes": [
+                {
+                  "at": "2.1.6",
+                  "status": "affected"
+                },
+                {
+                  "at": "2.1.9",
+                  "status": "unaffected"
+                }
+              ],
+              "versionType": "semver"
+            },
+            {
+              "version": "3.0.0",
+              "status": "unaffected",
+              "lessThan": "*",
+              "versionType": "semver"
+            }
+          ],
+          "defaultStatus": "unaffected"
+        }
+      ],
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges. This issue affects: 1.0 versions before 1.0.6, 2.1 versions from 2.16 until 2.1.9.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "OS Command Injection vulnerability <tt>parseFilename</tt> function of <tt>example.php</tt> in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges.<br><br>This issue affects:<br><ul><li>1.0 versions before 1.0.6</li><li>2.1 versions from 2.16 until 2.1.9.</li></ul>"
+            }
+          ]
+        },
+        {
+          "lang": "eo",
+          "value": "OS-komand-injekta vundebleco parseFilename funkcio de example.php en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn. Ĉi tiu afero efikas: 1.0-versioj antaŭ 1.0.6, 2.1-versioj de 2.16 ĝis 2.1.9.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "OS-komand-injekta vundebleco <tt>parseFilename</tt> funkcio de <tt>example.php</tt> en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn.<br><br> Ĉi tiu afero efikas:<br><ul><li>1.0-versioj antaŭ 1.0.6</li><li>2.1-versioj de 2.16 ĝis 2.1.9.</li></ul>"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "GENERAL"
+            }
+          ],
+          "cvssV3_1": {
+            "version": "3.1",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+          }
+        },
+        {
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "If the enhanced host protection mode is turned on, this vulnerability can only be exploited to run os commands as user 'nobody'. Privilege escalation is not possible."
+            }
+          ],
+          "cvssV3_1": {
+            "version": "3.1",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "LOW",
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+          }
+        }
+      ],
+      "solutions": [
+        {
+          "lang": "en",
+          "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions."
+            }
+          ]
+        }
+      ],
+      "workarounds": [
+        {
+          "lang": "en",
+          "value": "Disable the web management interface with the command\n> service disable webmgmt",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Disable the web management interface with the command<br><pre>&gt; <b>service disable webmgmt</b></pre>"
+            }
+          ]
+        }
+      ],
+      "configurations": [
+        {
+          "lang": "en",
+          "value": "Web management interface should be enabled.\n> service status webmgmt\nwebmgmt running",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Web management interface should be enabled.<br><pre>&gt; <b>service status webmgmt</b><br>webmgmt running</pre>"
+            }
+          ]
+        }
+      ],
+      "exploits": [
+        {
+          "lang": "en",
+          "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available."
+            }
+          ]
+        }
+      ],
+      "timeline": [
+        {
+          "time": "2001-09-01T07:31:00.000Z",
+          "lang": "en",
+          "value": "Issue discovered by Alice using Acme Autofuzz"
+        },
+        {
+          "time": "2021-09-02T16:36:00.000Z",
+          "lang": "en",
+          "value": "Confirmed by Bob"
+        },
+        {
+          "time": "2021-09-07T16:37:00.000Z",
+          "lang": "en",
+          "value": "Fixes released"
+        }
+      ],
+      "credits": [
+        {
+          "lang": "en",
+          "value": "Alice",
+          "type": "finder"
+        },
+        {
+          "lang": "en",
+          "value": "Bob",
+          "type": "analyst"
+        },
+        {
+          "lang": "en",
+          "value": "Acme Autofuzz",
+          "type": "tool"
+        }
+      ],
+      "references": [
+        {
+          "url": "https://example.org/ESA-22-11-CVE-1337-1234",
+          "name": "ESA-22-11",
+          "tags": [
+            "vendor-advisory"
+          ]
+        },
+        {
+          "url": "https://example.com/blog/alice/pwning_example_enterprise",
+          "name": "Pwning Example Enterprise",
+          "tags": [
+            "technical-description",
+            "third-party-advisory"
+          ]
+        },
+        {
+          "url": "https://example.org/bugs/EXAMPLE-1234",
+          "name": "EXAMPLE-1234",
+          "tags": [
+            "issue-tracking"
+          ]
+        },
+        {
+          "url": "https://example.org/ExampleEnterprise",
+          "tags": [
+            "product"
+          ]
+        }
+      ],
+      "source": {
+        "defects": [
+          "EXAMPLE-1234"
+        ],
+        "advisory": "ESA-22-11",
+        "discovery": "EXTERNAL"
+      },
+      "taxonomyMappings": [
+        {
+          "taxonomyName": "ATT&CK",
+          "taxonomyVersion": "v9",
+          "taxonomyRelations": [
+            {
+              "taxonomyId": "T1190",
+              "relationshipName": "mitigated by",
+              "relationshipValue": "M1048"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/data/CVEv5_basic-example.json
+++ b/tests/data/CVEv5_basic-example.json
@@ -1,0 +1,52 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0",
+    "cveMetadata": {
+      "cveId": "CVE-1337-1234",
+      "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+      "state": "PUBLISHED"
+    },
+    "containers": {
+      "cna": {
+        "providerMetadata": {
+          "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
+        },
+        "problemTypes": [
+          {
+            "descriptions": [
+              {
+                "lang": "en",
+                "description": "CWE-78 OS Command Injection"
+              }
+            ]
+          }
+        ],
+        "affected": [
+          {
+            "vendor": "Example.org",
+            "product": "Example Enterprise",
+            "versions": [
+              {
+                "version": "1.0.0",
+                "status": "affected",
+                "lessThan": "1.0.6",
+                "versionType": "semver"
+              }
+            ],
+            "defaultStatus": "unaffected"
+          }
+        ],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
+          }
+        ],
+        "references": [
+          {
+            "url": "https://example.org/ESA-22-11-CVE-1337-1234"
+          }
+        ]
+      }
+    }
+  }

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,0 +1,6 @@
+# CVE v5 JSON Record Examples
+
+The example CVE records (`CVEv5_*.json`) in this directory are copied verbatim from:
+https://github.com/CVEProject/cve-schema/tree/v5.0.0/schema/v5.0/docs
+
+They should be kept up to date with the schema versions in `cvelib/schemas/`.

--- a/tests/test_cve_api.py
+++ b/tests/test_cve_api.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cvelib.cve_api import CveApi, CveRecord, CveRecordValidationError
+
+
+def test_full_schema_validation():
+    with open(Path(__file__).parent / "data/CVEv5_advanced-example.json") as record_file:
+        cve_json = json.load(record_file)
+    try:
+        CveRecord.validate(cve_json, CveRecord.Schemas.V5_SCHEMA)
+    except CveRecordValidationError as exc:
+        pytest.fail(f"{exc}: {exc.errors}")
+
+
+def test_container_schema_validation():
+    with open(Path(__file__).parent / "data/CVEv5_basic-example.json") as record_file:
+        cve_json = json.load(record_file)
+
+    cve_container = CveApi._extract_cna_container(cve_json)
+    try:
+        CveRecord.validate(cve_container, CveRecord.Schemas.CNA_PUBLISHED)
+    except CveRecordValidationError as exc:
+        pytest.fail(f"{exc}: {exc.errors}")
+
+
+def test_invalid_record_schema_validation():
+    with pytest.raises(CveRecordValidationError, match="^Schema validation.*failed$") as exc_info:
+        CveRecord.validate({}, CveRecord.Schemas.CNA_REJECTED)
+
+    exc_errors = exc_info._excinfo[1].errors
+    assert "'providerMetadata' is a required property" in exc_errors
+    assert "'rejectedReasons' is a required property" in exc_errors

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,5 @@ deps =
     mypy
     types-click
     types-requests
+    types-jsonschema
 commands = mypy cvelib


### PR DESCRIPTION
- Records are now validated before being submitted (can be disabled when using lib interface)
- Full records are now supported, the CNA container is extracted automatically.
- providerMetadata is filled in automatically if missing.

Resolves #42 
Resolves #39
Resolves #19