### PR TITLE
Relax required json-schema version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 install_requires = [
     "click>=7.1.2",
     "requests>=2.24.0",
-    "jsonschema>=4.17.0",
+    "jsonschema>=4.7.2",
 ]
 
 tests_require = [


### PR DESCRIPTION
...to support distros that don't ship the latest and greatest version. There are no relevant changes since 4.7.0 that would require us to use the latest version.

Resolves #53 