### PR TITLE
Improve error reporting in validation exception

### DIFF
--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -50,10 +50,11 @@ class CveRecord:
             schema = json.load(schema_file)
 
         validator = Draft7Validator(schema)
-        errors = [error.message for error in sorted(validator.iter_errors(cve_json), key=str)]
+        errors = sorted(validator.iter_errors(cve_json), key=lambda e: e.message)
         if errors:
+            errors_str = "\n".join(e.message for e in errors)
             raise CveRecordValidationError(
-                f"Schema validation against {schema_path} failed", errors
+                f"Schema validation against {schema_path} failed:\n{errors_str}", errors
             )
 
 

--- a/tests/test_cve_api.py
+++ b/tests/test_cve_api.py
@@ -27,9 +27,14 @@ def test_container_schema_validation():
 
 
 def test_invalid_record_schema_validation():
-    with pytest.raises(CveRecordValidationError, match="^Schema validation.*failed$") as exc_info:
+    with pytest.raises(CveRecordValidationError, match="^Schema validation.*failed") as exc_info:
         CveRecord.validate({}, CveRecord.Schemas.CNA_REJECTED)
 
+    # Verify errors are reported in exception message
+    assert "'providerMetadata' is a required property" in str(exc_info.value)
+    assert "'rejectedReasons' is a required property" in str(exc_info.value)
+
+    # Verify error objects are present in exception object.
     exc_errors = exc_info._excinfo[1].errors
-    assert "'providerMetadata' is a required property" in exc_errors
-    assert "'rejectedReasons' is a required property" in exc_errors
+    assert "'providerMetadata' is a required property" in exc_errors[0].message
+    assert "'rejectedReasons' is a required property" in exc_errors[1].message


### PR DESCRIPTION
Store entire validation objects in the exception but also display their messages in the initial exception message. This is much more user-focused since digging out the actual error messages is repetitive unless done for a very specific reason.