### PR TITLE
Make CveRecordValidationError picklable

### DIFF
--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -21,9 +21,13 @@ class Constants(str, Enum):
 
 
 class CveRecordValidationError(Exception):
-    def __init__(self, message, errors):
-        super().__init__(message)
+    def __init__(self, *args, **kwargs):
+        errors = kwargs.pop("errors", None)
         self.errors = errors
+        super().__init__(*args, **kwargs)
+
+    def __reduce__(self):
+        return CveRecordValidationError, (self.args,)
 
 
 class CveRecord:
@@ -54,7 +58,7 @@ class CveRecord:
         if errors:
             errors_str = "\n".join(e.message for e in errors)
             raise CveRecordValidationError(
-                f"Schema validation against {schema_path} failed:\n{errors_str}", errors
+                f"Schema validation against {schema_path} failed:\n{errors_str}", errors=errors
             )
 
 


### PR DESCRIPTION
This prevents PicklingError errors when the exception is stored e.g. by Celery when creating TaskResult records:

```
{"exc_type": "MaybeEncodingError", "exc_message":
["'PicklingError(\"Can\\'t pickle <class
\\'cvelib.cve_api.CveRecordValidationError\\'>: it\\'s not the same
object as cvelib.cve_api.CveRecordValidationError\")'", "\"(1,
<ExceptionInfo: CveRecordValidationError('Schema validation against
/usr/local/lib/python3.9/site-packages/cvelib/schemas/published_cna_container_5.0.0.json
failed')>, None)\""], "exc_module": "billiard.pool"}
```