### PR TITLE
Skip required options when using help option

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -559,3 +559,22 @@ def test_show_org():
             "├─ Created:\tWed Apr 21 02:09:07 2021 +0000\n"
             "└─ Modified:\tWed Apr 21 02:09:07 2021 +0000\n"
         )
+
+
+class TestSubcommandHelp:
+    def test_required_opts(self):
+        with mock.patch("cvelib.cli.CveApi.show_org") as show_org:
+            show_org.return_value = {}
+            runner = CliRunner()
+            result = runner.invoke(cli, ["org"])
+            assert result.exit_code == 2, result.output
+            assert "Error: Missing option" in result.output
+
+    def test_exit_on_help(self):
+        with mock.patch("cvelib.cli.CveApi.show_org") as show_org:
+            show_org.return_value = {}
+            runner = CliRunner()
+            result = runner.invoke(cli, ["org", "--help"])
+            assert result.exit_code == 0, result.output
+            # The command is named after the function that is called.
+            assert result.output.startswith("Usage: cli org")


### PR DESCRIPTION
This lets users use `cve list -h` without having to also specify auth-related options (user, org, api key) that are required for non-help actions.