### PR TITLE
Switch to ruff for linting and import sorting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
         tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        tox_env: [py37, py38, py39, py310, py311, black, isort, flake8, mypy]
+        tox_env: [py37, py38, py39, py310, py311, black, ruff, mypy]
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.black]
 line-length = 100
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+line-length = 100
+# https://beta.ruff.rs/docs/rules/
+select = ["F", "E", "W", "I", "N"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}, black, isort, flake8, mypy
+envlist = py{37,38,39,310,311}, black, ruff, mypy
 
 [testenv]
 deps = pytest
@@ -9,31 +9,9 @@ commands = pytest {posargs:tests/}
 deps = black
 commands = black --check .
 
-[testenv:isort]
-deps = isort
-commands = isort --check --diff .
-
-[flake8]
-# NOTE: Any ignored errors/warnings specified below are subjective and can be changed based on
-#       common agreement of all developers contributing to this project.
-#
-# W504: line break after binary operator
-# W503: line break before binary operator (used by black formatter)
-# E203: whitespace before ':' (used by black formatter)
-#
-# TODO: move config to pyproject.toml after https://github.com/PyCQA/flake8/issues/234 is resolved.
-ignore = W504,W503,E203
-# Keep in sync with black.line-length in pyproject.toml
-max-line-length = 100
-exclude = .git/,venv/,.tox/,build/
-
-[testenv:flake8]
-deps = flake8
-commands = flake8
-
-[testenv:manpages]
-deps = click-man
-commands = click-man cve
+[testenv:ruff]
+deps = ruff
+commands = ruff check .
 
 [testenv:mypy]
 deps =
@@ -42,3 +20,7 @@ deps =
     types-requests
     types-jsonschema
 commands = mypy cvelib
+
+[testenv:manpages]
+deps = click-man
+commands = click-man cve


### PR DESCRIPTION
The upside here is faster linting, less CI (and faster) stages, easier configuration through pyproject.toml, more sane defaults (i.e. .gitignore is honored), and other goodness.