### PR TITLE
Fix #87 - load cve json, schema file with parse_float=decimal.Decimal to allow CVSS comparison to validate

### DIFF
--- a/cvelib/cli.py
+++ b/cvelib/cli.py
@@ -1,3 +1,4 @@
+import decimal
 import json
 import re
 import sys
@@ -351,9 +352,9 @@ def publish(
 
     try:
         if cve_json_str is not None:
-            cve_json = json.loads(cve_json_str)
+            cve_json = json.loads(cve_json_str, parse_float=decimal.Decimal)
         elif cve_json_file is not None:
-            cve_json = json.load(cve_json_file)
+            cve_json = json.load(cve_json_file, parse_float=decimal.Decimal)
         else:
             raise click.BadParameter(
                 "must provide CNA JSON data using one of: "
@@ -443,9 +444,9 @@ def publish_adp(
         )
     try:
         if adp_json_str is not None:
-            cve_json = json.loads(adp_json_str)
+            cve_json = json.loads(adp_json_str, parse_float=decimal.Decimal)
         elif adp_json_file is not None:
-            cve_json = json.load(adp_json_file)
+            cve_json = json.load(adp_json_file, parse_float=decimal.Decimal)
         else:
             raise click.BadParameter(
                 "must provide ADP JSON record using one of: "
@@ -534,9 +535,9 @@ def reject(
 
     try:
         if cve_json_str is not None:
-            cve_json = json.loads(cve_json_str)
+            cve_json = json.loads(cve_json_str, parse_float=decimal.Decimal)
         elif cve_json_file is not None:
-            cve_json = json.load(cve_json_file)
+            cve_json = json.load(cve_json_file, parse_float=decimal.Decimal)
         else:
             cve_json = None
     except json.JSONDecodeError as exc:

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -51,7 +51,7 @@ class CveRecord:
             schema_path = cls.Schemas.CNA_PUBLISHED
 
         with open(schema_path) as schema_file:
-            schema = json.load(schema_file)
+            schema = json.load(schema_file, parse_float=decimal.Decimal)
 
         validator = Draft7Validator(schema)
         errors = sorted(validator.iter_errors(cve_json), key=lambda e: e.message)

--- a/cvelib/cve_api.py
+++ b/cvelib/cve_api.py
@@ -1,3 +1,4 @@
+import decimal
 import json
 from datetime import datetime
 from enum import Enum


### PR DESCRIPTION
Fixes https://github.com/RedHatProductSecurity/cvelib/issues/87
both json cve data and the schema file must be loaded with `json.load(filename, parse_float=decimal.Decimal)`